### PR TITLE
removed uneeded include

### DIFF
--- a/converter/src/converter.c
+++ b/converter/src/converter.c
@@ -1,5 +1,4 @@
 #include <converter.h>
-#include <stdio.h>
 #include <stdbool.h>
 
 // The type of a single Unicode codepoint


### PR DESCRIPTION
This is useful for freestanding build where this header might not be available